### PR TITLE
[15.0][FIX] oca_dependencies.txt: required update due to fieldservice_sale_crm_lead_schduration

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 field-service
+slv-crm https://github.com/solvosci/slv-crm


### PR DESCRIPTION
@LucPinheiro @ChristianSantamaria `fieldservice_sale_crm_lead_schduration` depends on an external addon (`crm_lead_date_duration`, that belongs to other repo), so `oca_dependencies.txt` file should be updated. 