### PR TITLE
[15.0][FIX] fieldservice_person_salary: added missing dependency in manifest

### DIFF
--- a/fieldservice_person_salary/README.rst
+++ b/fieldservice_person_salary/README.rst
@@ -27,6 +27,13 @@ salary.
 .. contents::
    :local:
 
+Known issues / Roadmap
+======================
+
+Remove ``fieldservice_person_extended`` dependency moving ``vat`` and
+``acc_number`` ``fsm.order.salary`` model fields (and views) to a bridge addon
+between this one and ``fieldservice_person_extended``.
+
 Bug Tracker
 ===========
 

--- a/fieldservice_person_salary/__manifest__.py
+++ b/fieldservice_person_salary/__manifest__.py
@@ -8,10 +8,10 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "15.0.1.3.0",
+    "version": "15.0.1.3.1",
     "category": "Field Service",
     "website": "https://github.com/solvosci/slv-field-service",
-    "depends": ["fieldservice"],
+    "depends": ["fieldservice", "fieldservice_person_extended"],
     "data": [
         "security/ir.model.access.csv",
         "views/fsm_order_views.xml",

--- a/fieldservice_person_salary/readme/ROADMAP.rst
+++ b/fieldservice_person_salary/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+Remove ``fieldservice_person_extended`` dependency moving ``vat`` and
+``acc_number`` ``fsm.order.salary`` model fields (and views) to a bridge addon
+between this one and ``fieldservice_person_extended``.

--- a/fieldservice_person_salary/static/description/index.html
+++ b/fieldservice_person_salary/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
 <title>FieldService Person Salary</title>
 <style type="text/css">
 
@@ -373,17 +373,24 @@ salary.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<p>Remove <tt class="docutils literal">fieldservice_person_extended</tt> dependency moving <tt class="docutils literal">vat</tt> and
+<tt class="docutils literal">acc_number</tt> <tt class="docutils literal">fsm.order.salary</tt> model fields (and views) to a bridge addon
+between this one and <tt class="docutils literal">fieldservice_person_extended</tt>.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/solvosci/slv-field-service/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -391,15 +398,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Solvos</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>Lucia Pinheiro &lt;<a class="reference external" href="mailto:lucia.pinheiro&#64;solvos.es">lucia.pinheiro&#64;solvos.es</a>&gt;</li>
 <li>David Alonso &lt;<a class="reference external" href="mailto:david.alonso&#64;solvos.es">david.alonso&#64;solvos.es</a>&gt;</li>
@@ -407,7 +414,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/solvosci/slv-field-service/tree/15.0/fieldservice_person_salary">solvosci/slv-field-service</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
There are two FSM Person Salary fields that make this addon dependent on fieldservice_person_extended addon.
Added a ROADMAP reference to this issue, because this is a workaround and a bridge addon should be the best solution for this.

cc @ChristianSantamaria @LucPinheiro 